### PR TITLE
Set OpenVPN to version 2.3 because latest does not work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         restart: always
 
     openvpn:
-        image: kylemanna/openvpn
+        image: kylemanna/openvpn:2.3
         volumes:
             - .:/local
             - ./config:/etc/openvpn


### PR DESCRIPTION
The latest version of kylemanna/openvpn is not working. Setting it to 2.3 fixed the problem.