### PR TITLE
Replace socat command with docker container

### DIFF
--- a/commons.sh
+++ b/commons.sh
@@ -8,21 +8,13 @@ function disconnectVPN() {
  	osascript -e "tell application \"Tunnelblick\"" -e "disconnect \"docker-for-mac\"" -e "end tell" &> /dev/null
 }
 
-function startupContainer() {
+function startupContainers() {
 	docker-compose up -d
 }
 
-function shutdownContainer() {
+function shutdownContainers() {
   docker-compose stop
 	docker ps -f name="dockermacnetwork_proxy_1" -f name="dockermacnetwork_openvpn_1" -q | xargs docker rm -f &> /dev/null
-}
-
-function startTPCListenHack() {
-	socat TCP-LISTEN:2375,reuseaddr,fork UNIX-CONNECT:/var/run/docker.sock &
-}
-
-function stopTPCListenHack() {
-	ps aux | grep "socat TCP-LISTEN:2375" | cut -d ' ' -f2 | xargs kill -9 &> /dev/null
 }
 
 function sleepFor() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,11 @@ services:
         command: /local/helpers/run.sh
         restart: always
 
+    docker_api:
+        build: .
+        ports:
+            - "127.0.0.1:2375:2375"
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock
+        command: TCP-LISTEN:2375,fork UNIX-CONNECT:/var/run/docker.sock
+        restart: always

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -7,11 +7,7 @@ disconnectVPN
 
 echo ""
 echo "2 - Stopping VPN and Proxy containers..."
-shutdownContainer
+shutdownContainers
 
 echo ""
-echo "3 - Killing socat..."
-stopTPCListenHack
-
-echo ""
-echo "4 - Done! You're free, go out and see the world, child."
+echo "3 - Done! You're free, go out and see the world, child."

--- a/startup.sh
+++ b/startup.sh
@@ -3,20 +3,16 @@
 source commons.sh
 
 echo "1 - Starting VPN and Proxy containers..."
-startupContainer
+startupContainers
 
 echo ""
 echo "2 - Waiting 5 secs for the containers to be fully functional..."
 sleepFor 5
 
 echo ""
-echo "3 - Exposing port 2375 for Docker remote API access using socat..."
-startTPCListenHack
-
-echo ""
-echo "4 - Connecting to the VPN from Tunnelblick..."
+echo "3 - Connecting to the VPN from Tunnelblick..."
 connectVPN
 
 echo ""
-echo "5 - Done! Just make sure Tunnelblick has successfully connected to the VPN and you're good to go!"
+echo "4 - Done! Just make sure Tunnelblick has successfully connected to the VPN and you're good to go!"
 


### PR DESCRIPTION
By replacing the socat command with a docker container, the startup.sh script doesn't have to be executed every time the system is rebooted. This is due to the fact that the docker daemon will automatically start these containers with a restart policy of "always".